### PR TITLE
feat(cryptomator): Disabled automatic update-checking

### DIFF
--- a/packages/cryptomator/tools/chocolateyInstall.ps1
+++ b/packages/cryptomator/tools/chocolateyInstall.ps1
@@ -18,5 +18,31 @@ Install-ChocolateyPackage @packageArgs
 $installLocation = Get-AppInstallLocation $packageArgs.registryUninstallerKey
 if ($installLocation) {
   Write-Host "$packageName installed to '$installLocation'"
+  $file = "C:\Program Files\Cryptomator\app\Cryptomator.cfg"
+
+  # Disable the "Check for updates" dialog in Cryptomator
+  # See: https://github.com/cryptomator/cryptomator/pull/3118
+  # Check if the file exists
+  if (Test-Path $file) {
+    # Read the content of the file
+    $content = Get-Content $file -Raw
+
+    # Check if the [JavaOptions] section exists
+    if ($content -match '\[JavaOptions\]') {
+      # Add the line to the [JavaOptions] section
+      $content += "`njava-options=-Dcryptomator.disableUpdateCheck=true"
+      
+      # Write the modified content back to the file
+      $content | Set-Content $file -Force
+      Write-Host "File modified successfully."
+    }
+    else {
+      Write-Host "[JavaOptions] section not found in the file."
+    }
+  }
+  else {
+    Write-Host "File does not exist."
+  }
+
 }
 else { Write-Warning "Can't find $PackageName install location" }


### PR DESCRIPTION
I've added some code that modifies the System-wide `cryptomator.cfg` config file and adds the `java-options=-Dcryptomator.disableUpdateCheck=true` to the `[JavaOptions]` section so that Cryptomator does not check for updates on its own. 

See: https://github.com/cryptomator/cryptomator/pull/3118