### PR TITLE
Cryptomator: Disable app internal update check by MSI property.

### DIFF
--- a/packages/cryptomator/tools/chocolateyInstall.ps1
+++ b/packages/cryptomator/tools/chocolateyInstall.ps1
@@ -9,40 +9,8 @@ $packageArgs = @{
   url64bit               = $url64bit
   checksum64             = $checksum64
   checksumType64         = 'sha256'
-  silentArgs             = '/qn /norestart'
+  silentArgs             = '/qn /norestart DISABLEUPDATECHECK=1'
   validExitCodes         = @(0)
   registryUninstallerKey = 'Cryptomator'
 }
 Install-ChocolateyPackage @packageArgs
-
-$installLocation = Get-AppInstallLocation $packageArgs.registryUninstallerKey
-if ($installLocation) {
-  Write-Host "$packageName installed to '$installLocation'"
-  $file = "C:\Program Files\Cryptomator\app\Cryptomator.cfg"
-
-  # Disable the "Check for updates" dialog in Cryptomator
-  # See: https://github.com/cryptomator/cryptomator/pull/3118
-  # Check if the file exists
-  if (Test-Path $file) {
-    # Read the content of the file
-    $content = Get-Content $file -Raw
-
-    # Check if the [JavaOptions] section exists
-    if ($content -match '\[JavaOptions\]') {
-      # Add the line to the [JavaOptions] section
-      $content += "`njava-options=-Dcryptomator.disableUpdateCheck=true"
-      
-      # Write the modified content back to the file
-      $content | Set-Content $file -Force
-      Write-Host "File modified successfully."
-    }
-    else {
-      Write-Host "[JavaOptions] section not found in the file."
-    }
-  }
-  else {
-    Write-Host "File does not exist."
-  }
-
-}
-else { Write-Warning "Can't find $PackageName install location" }


### PR DESCRIPTION
Also removes the custom post-install script.

See also https://github.com/cryptomator/cryptomator/pull/3961.

Note, that this holds for the next Minor release which is planned in october. So maybe wait a bit until merge (or merge after official release).